### PR TITLE
refactor usage from sql client to microsoft client

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ test_script:
 after_test:
   - codecov -f "./tests/coverage.net9.0.xml" -t $(codecov_token)
 environment:
-  sql_connection: Server=(local)\SQL2019;Database=master;User ID=sa;Password=Password12!;
+  sql_connection: Server=(local)\SQL2019;Database=master;User ID=sa;Password=Password12!;TrustServerCertificate=True;
   postgres_connection: Server=localhost;Port=5432;Database=postgres;Username=postgres;Password=Password12!;
   mysql_connection: Server=localhost;Port=3306;Database=mysql;User Id=root;Password=Password12!;SSL Mode=Required;
   codecov_token:

--- a/src/MinimigLib/ConnectionContext.cs
+++ b/src/MinimigLib/ConnectionContext.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Text.RegularExpressions;
+using Microsoft.Data.SqlClient;
 using MySql.Data.MySqlClient;
 using Npgsql;
 

--- a/src/MinimigLib/MinimigLib.csproj
+++ b/src/MinimigLib/MinimigLib.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySql.Data" Version="9.0.0" />
-    <PackageReference Include="Npgsql" Version="8.0.3" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageReference Include="MySql.Data" Version="9.1.0" />
+    <PackageReference Include="Npgsql" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="MinimigTests"/>
+    <InternalsVisibleTo Include="MinimigTests" />
   </ItemGroup>
 
 </Project>

--- a/src/MinimigLib/Options.cs
+++ b/src/MinimigLib/Options.cs
@@ -48,7 +48,7 @@ public class Options
             throw new Exception("No database assign to infer Connection String");
 
         if (provider is DatabaseProvider.sqlserver)
-            return $"Persist Security Info=False;Integrated Security=true;Initial Catalog={Database};server={(string.IsNullOrEmpty(Server) ? "." : Server)}";
+            return $"Persist Security Info=False;Integrated Security=true;Initial Catalog={Database};server={(string.IsNullOrEmpty(Server) ? "." : Server)};TrustServerCertificate=True;";
         else if (provider is DatabaseProvider.postgresql)
             return $"Server={(string.IsNullOrEmpty(Server) ? "localhost" : Server)};Port=5432;Database={Database};Integrated Security=true;";
         else if (provider is DatabaseProvider.mysql)

--- a/tests/Integration/ConnectionContextTests.cs
+++ b/tests/Integration/ConnectionContextTests.cs
@@ -19,7 +19,7 @@ public class ConnectionContextTests
         //This logic allows to pass the connection from ci or locally
         string sqlServerConnEnv = Environment.GetEnvironmentVariable("Sql_Connection");
         if (string.IsNullOrEmpty(sqlServerConnEnv))
-            sqlServerConnEnv = "Server=(local);Database=master;Trusted_Connection=true;";
+            sqlServerConnEnv = "Server=(local);Database=master;Trusted_Connection=true;TrustServerCertificate=True;";
 
         string postgresConnEnv = Environment.GetEnvironmentVariable("Postgres_Connection");
         if (string.IsNullOrEmpty(postgresConnEnv))

--- a/tests/Unit/OptionsTests.cs
+++ b/tests/Unit/OptionsTests.cs
@@ -81,7 +81,7 @@ public class OptionsTests
     public void Get_connection_string_with_server_and_database_sqlserver(string inputServer, string inputDatabase)
     {
         //Arrange
-        string inputConnection = $"Persist Security Info=False;Integrated Security=true;Initial Catalog={inputDatabase};server={inputServer}";
+        string inputConnection = $"Persist Security Info=False;Integrated Security=true;Initial Catalog={inputDatabase};server={inputServer};TrustServerCertificate=True;";
         var options = new Options() { Server = inputServer, Database = inputDatabase };
 
         //Act
@@ -111,7 +111,7 @@ public class OptionsTests
     public void Get_connection_string_with_database(string inputDatabase)
     {
         //Arrange
-        string inputConnection = $"Persist Security Info=False;Integrated Security=true;Initial Catalog={inputDatabase};server=.";
+        string inputConnection = $"Persist Security Info=False;Integrated Security=true;Initial Catalog={inputDatabase};server=.;TrustServerCertificate=True;";
         var options = new Options() { Database = inputDatabase };
 
         //Act

--- a/tests/Unit/SqlExtensionsTests.cs
+++ b/tests/Unit/SqlExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Data.SqlClient;
+﻿using Microsoft.Data.SqlClient;
 using Minimig;
 using Xunit;
 


### PR DESCRIPTION
Since the sql client has been deprecated, we need to move to the microsoft sql client library.

# Description

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
