### PR TITLE
Add .NET 10 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ before_build:
 build_script:
   - cmd: dotnet build . -v quiet
 test_script:
-  - cmd: dotnet test ./tests/MinimigTests.csproj /p:AltCover=true /p:AltCoverAssemblyExcludeFilter="xunit" /p:AltCoverAssemblyFilter="testhost|Microsoft"
+  - cmd: dotnet test ./tests/MinimigTests.csproj /p:AltCover=true /p:AltCoverAssemblyFilter="testhost|Microsoft|xunit|MinimigTests|AltCover"
 after_test:
   - codecov -f "./tests/coverage.net10.0.xml" -t $(codecov_token)
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ nuget:
 install:
 - ps: |
     Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile "$env:temp\dotnet-install.ps1"
-    & $env:temp\dotnet-install.ps1 -Architecture x64 -Version '9.0.100' -InstallDir "$env:ProgramFiles\dotnet"
+    & $env:temp\dotnet-install.ps1 -Architecture x64 -Version '10.0.110' -InstallDir "$env:ProgramFiles\dotnet"
 before_build:
   - cmd: dotnet --version
   - choco install codecov
@@ -25,7 +25,7 @@ build_script:
 test_script:
   - cmd: dotnet test ./tests/MinimigTests.csproj /p:AltCover=true /p:AltCoverAssemblyExcludeFilter="xunit" /p:AltCoverAssemblyFilter="testhost|Microsoft"
 after_test:
-  - codecov -f "./tests/coverage.net9.0.xml" -t $(codecov_token)
+  - codecov -f "./tests/coverage.net10.0.xml" -t $(codecov_token)
 environment:
   sql_connection: Server=(local)\SQL2019;Database=master;User ID=sa;Password=Password12!;TrustServerCertificate=True;
   postgres_connection: Server=localhost;Port=5432;Database=postgres;Username=postgres;Password=Password12!;

--- a/src/Minimig/Minimig.csproj
+++ b/src/Minimig/Minimig.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ToolCommandName>mig</ToolCommandName>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <PackageId>Minimig</PackageId>
     <AssemblyTitle>Minimig</AssemblyTitle>
@@ -18,7 +18,7 @@
     <PackageTags>migration;sql;sqlserver;database;postgresql;mysql</PackageTags>
     <Description>A simple database migrator for SQL Server, PostgreSQL and MySQL</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageReleaseNotes>Add support for .net9.0. Remove support for net6.0</PackageReleaseNotes>
+    <PackageReleaseNotes>Add support for .NET 10. Remove support for .NET 9.</PackageReleaseNotes>
     <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <TieredCompilation>true</TieredCompilation>

--- a/src/MinimigLib/MinimigLib.csproj
+++ b/src/MinimigLib/MinimigLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <NoWarn>SYSLIB1045</NoWarn>
   </PropertyGroup>

--- a/tests/MinimigTests.csproj
+++ b/tests/MinimigTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <TestTfmsInParallel>false</TestTfmsInParallel>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary

- Replace the .NET 9 target with .NET 10 while retaining .NET 8 compatibility.
- Update AppVeyor to install and test with the .NET 10 SDK.
- Correct AltCover filtering so Codecov reports library coverage instead of test infrastructure.

## Validation

- Clean build succeeds with no warnings.
- All 262 tests pass across .NET 8 and .NET 10 against SQL Server, PostgreSQL, and MySQL.
- AltCover reports 86.35% point coverage for `MinimigLib` on both targets.

Closes #262
Closes #289