### PR TITLE
Upgrade database provider packages

### DIFF
--- a/src/MinimigLib/MinimigLib.csproj
+++ b/src/MinimigLib/MinimigLib.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
-    <PackageReference Include="MySql.Data" Version="9.5.0" />
-    <PackageReference Include="Npgsql" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageReference Include="MySql.Data" Version="26.7.0" />
+    <PackageReference Include="Npgsql" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Upgrade `Microsoft.Data.SqlClient` from 6.1.4 to 7.0.2.
- Upgrade `MySql.Data` from 9.5.0 to 26.7.0.
- Upgrade `Npgsql` from 9.0.4 to 10.0.3.

## Validation

- Clean build succeeds with no warnings.
- All 262 tests pass across .NET 8 and .NET 10.
- Integration tests pass against SQL Server, PostgreSQL, and MySQL.